### PR TITLE
macOSで実行させるための修正について

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ $ cd build
 $ cmake -G "Visual Studio 15 2017 Win64" ..
 ```
 
+### Setup (macOS & Xcode)
+
+```bash
+$ git clone https://github.com/g-truc/glm
+$ git clone https://github.com/glfw/glfw
+$ git clone https://github.com/syoyo/tinyobjloader
+$ git clone https://github.com/ocornut/imgui.git
+$ mkdir build
+$ cd build
+$ cmake -G Xcode ..
+```
+
 ### License
 
 MIT license. See ``LICENSE`` file for detail.

--- a/src/vis.hpp
+++ b/src/vis.hpp
@@ -92,7 +92,7 @@ public:
     bool init() {
         #pragma region Programs
         const char* vscode = R"x(
-            #version 430 core
+            #version 410 core
             layout (location = 0) in vec2 position;
             out gl_PerVertex {
                 vec4 gl_Position;
@@ -104,8 +104,8 @@ public:
             }
         )x";
         const char* fscode = R"x(
-            #version 430 core
-            layout (binding = 0) uniform sampler2D tex;
+            #version 410 core
+            uniform sampler2D tex;
             in vec2 uv;
             out vec4 color;
             void main() {
@@ -278,8 +278,9 @@ public:
         window_ = [&]() -> GLFWwindow* {
             // GLFW window
             glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
             glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+            glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
             #ifdef _DEBUG
             glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);
             #endif
@@ -292,7 +293,7 @@ public:
             IMGUI_CHECKVERSION();
             ImGui::CreateContext();
             ImGui_ImplGlfw_InitForOpenGL(window, true);
-            ImGui_ImplOpenGL3_Init();
+            ImGui_ImplOpenGL3_Init("#version 410");
             ImGui::StyleColorsDark();
             return window;
         }();


### PR DESCRIPTION
このPRでは、macOSで実行させるために施した修正の内容を紹介します。
masterへのマージは、特に目的としていません。

### 修正について

残念ながら、最近のMacでもOpenGLのサポートは4.1止まりのため、
vis.hppで行っているOpenGL関連の処理を4.1用に修正します。
https://support.apple.com/ja-jp/HT202823

対応トピックは以下な感じです。
* glfw へのVer指定を4.1 にする。GLFW_OPENGL_FORWARD_COMPATも追加。
* シェーダのコードもOpenGL4.1用にする。
* ImGui の 内部で使われるシェーダのVer("#version 130")もエラーになるので、OpenGL4.1を明示的に指定する。

約10年ぶりにOpenGLを触ったので、GLSL周辺はよくわからないまま修正しています。
動いてはいますが、glUniform1i() が必要かもしれないです。。

### 試した環境

* macOS High Sierra
* Xcode10 beta
* MacBook Pro (13-inch, 2016)

### その他

macOSに限らない話ですが、`Scene::foreachTriangles()` で法線データを参照しているため、使用するOBJは頂点法線(vn)のあるデータを使用する必要があります。無いと落ちます。


